### PR TITLE
Improve character sheet sidebar styling

### DIFF
--- a/styles/character.css
+++ b/styles/character.css
@@ -449,13 +449,15 @@
 }
 
 .daggerheart-plus.sheet.character .character-sidebar-sheet {
-  padding: 0.75rem;
+  padding: var(--dh-space-md);
   background: var(--dhp-gradient);
   border-right: 2px solid var(--dhp-primary);
   box-shadow: 4px 0 8px var(--dhp-shadow);
+  border-radius: 0 var(--dh-radius-lg) var(--dh-radius-lg) 0;
+  backdrop-filter: blur(4px);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--dh-space-lg);
   overflow-y: auto;
   height: 100%;
   width: 100%;
@@ -520,7 +522,7 @@
 .daggerheart-plus.sheet.character .character-sidebar-sheet .shortcut-items-section {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--dh-space-lg);
   width: 100%;
   min-width: 0;
 }
@@ -528,10 +530,11 @@
 .daggerheart-plus.sheet.character .character-sidebar-sheet .equipment-section,
 .daggerheart-plus.sheet.character .character-sidebar-sheet .loadout-section,
 .daggerheart-plus.sheet.character .character-sidebar-sheet .experience-section {
-  background: rgba(0, 0, 0, 0.15);
-  border-radius: 8px;
-  padding: 0.75rem;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: var(--dh-radius-lg);
+  padding: var(--dh-space-md);
   border: 1px solid var(--dhp-border);
+  box-shadow: 0 2px 4px var(--dhp-shadow);
   transition: all 0.3s ease;
   width: 100%;
   box-sizing: border-box;
@@ -543,7 +546,7 @@
 .daggerheart-plus.sheet.character .character-sidebar-sheet .loadout-section:hover,
 .daggerheart-plus.sheet.character .character-sidebar-sheet .experience-section:hover {
   border-color: var(--dhp-primary);
-  box-shadow: 0 2px 4px var(--dhp-shadow);
+  box-shadow: 0 4px 8px var(--dhp-shadow);
 }
 
 .daggerheart-plus.sheet.character .character-sidebar-sheet .title {


### PR DESCRIPTION
## Summary
- Round and blur character sheet sidebar for a sleeker panel
- Add spacing variables and subtle card shadows to equipment, loadout, and experience sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a6a2b83c832e8451beba1c29b0c9